### PR TITLE
Fix for large screens flexbox display of the flip-cards

### DIFF
--- a/CSS/index.css
+++ b/CSS/index.css
@@ -1285,8 +1285,9 @@ footer .brand span {
 }
 .flip-cards .flip-card {
   background-color: transparent;
-  width: 500px;
+  max-width: 500px;
   height: 400px;
+  width: 33.33%;
   flex-basis: 33.33%;
   perspective: 1000px;
   margin: 2%;

--- a/components/flip-cards/flip-cards.less
+++ b/components/flip-cards/flip-cards.less
@@ -5,8 +5,9 @@
 
   .flip-card {
     background-color: transparent;
-    width: 500px;
+    max-width: 500px;
     height: 400px;
+    width: 33.33%;
     flex-basis: 33.33%;
     perspective: 1000px;
     margin: 2%;


### PR DESCRIPTION
Forgot to add in max-width property on flip-cards to correctly display the flip-cards on large screens